### PR TITLE
Create auth folder structure

### DIFF
--- a/src/auth/_helpers.ts
+++ b/src/auth/_helpers.ts
@@ -1,0 +1,11 @@
+// Utility helpers for authentication
+
+export async function loginWithJWT(email: string, password: string) {
+  // TODO: call login endpoint and return token
+  return Promise.resolve({ token: 'mock-token' })
+}
+
+export async function signupWithJWT(email: string, password: string) {
+  // TODO: call signup endpoint and return user info
+  return Promise.resolve({ user: { email } })
+}

--- a/src/auth/_models.ts
+++ b/src/auth/_models.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id?: string
+  email: string
+  // TODO: add other user fields
+}

--- a/src/auth/pages/jwt/Login.tsx
+++ b/src/auth/pages/jwt/Login.tsx
@@ -1,0 +1,102 @@
+import { FormEvent, useState } from 'react'
+
+interface Errors {
+  email?: string
+  password?: string
+}
+
+export default function Login() {
+  const [email, setEmail] = useState('admin@example.com')
+  const [password, setPassword] = useState('')
+  const [remember, setRemember] = useState(false)
+  const [errors, setErrors] = useState<Errors>({})
+
+  const validate = () => {
+    const newErrors: Errors = {}
+    const emailRegex = /^\S+@\S+\.\S+$/
+    if (!emailRegex.test(email)) {
+      newErrors.email = 'Please enter a valid email.'
+    }
+    if (!password) {
+      newErrors.password = 'Password is required.'
+    }
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    if (!validate()) return
+    // TODO: integrate login logic with JWT backend
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="bg-blue-50 text-blue-800 p-3 rounded text-center text-sm">
+          Use admin@example.com username and secret password.
+        </div>
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white p-8 shadow rounded space-y-6"
+        >
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="mt-1 w-full rounded border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+              placeholder="Email"
+            />
+            {errors.email && (
+              <p className="mt-1 text-sm text-red-600">{errors.email}</p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 w-full rounded border-gray-300 focus:border-blue-500 focus:ring-blue-500"
+              placeholder="Password"
+            />
+            {errors.password && (
+              <p className="mt-1 text-sm text-red-600">{errors.password}</p>
+            )}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <label className="flex items-center text-sm text-gray-700">
+              <input
+                type="checkbox"
+                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                checked={remember}
+                onChange={(e) => setRemember(e.target.checked)}
+              />
+              <span className="ml-2">Remember me</span>
+            </label>
+            <a href="#" className="text-sm text-blue-600 hover:underline">
+              Forgot Password?
+            </a>
+          </div>
+
+          <button
+            type="submit"
+            className="w-full rounded bg-blue-600 py-2 px-4 text-white hover:bg-blue-700 focus:bg-blue-700"
+          >
+            Sign In
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/auth/pages/jwt/Signup.tsx
+++ b/src/auth/pages/jwt/Signup.tsx
@@ -1,0 +1,32 @@
+import { FormEvent, useState } from 'react'
+
+export default function Signup() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    // TODO: integrate signup logic with JWT backend
+  }
+
+  return (
+    <div>
+      <h2>Sign up</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button type="submit">Create account</button>
+      </form>
+    </div>
+  )
+}

--- a/src/auth/pages/jwt/TwoFactorAuth.tsx
+++ b/src/auth/pages/jwt/TwoFactorAuth.tsx
@@ -1,0 +1,25 @@
+import { FormEvent, useState } from 'react'
+
+export default function TwoFactorAuth() {
+  const [code, setCode] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    // TODO: verify two-factor authentication code
+  }
+
+  return (
+    <div>
+      <h2>Two-Factor Authentication</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="text"
+          placeholder="Enter verification code"
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+        />
+        <button type="submit">Verify</button>
+      </form>
+    </div>
+  )
+}

--- a/src/auth/pages/jwt/reset-password/ResetPasswordChange.tsx
+++ b/src/auth/pages/jwt/reset-password/ResetPasswordChange.tsx
@@ -1,0 +1,32 @@
+import { FormEvent, useState } from 'react'
+
+export default function ResetPasswordChange() {
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    // TODO: send new password along with reset token
+  }
+
+  return (
+    <div>
+      <h2>Choose New Password</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="password"
+          placeholder="New password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          placeholder="Confirm password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+        <button type="submit">Update password</button>
+      </form>
+    </div>
+  )
+}

--- a/src/auth/pages/jwt/reset-password/ResetPasswordChanged.tsx
+++ b/src/auth/pages/jwt/reset-password/ResetPasswordChanged.tsx
@@ -1,0 +1,8 @@
+export default function ResetPasswordChanged() {
+  return (
+    <div>
+      <h2>Password Reset Successful</h2>
+      <p>Your password has been updated. You can now log in with your new credentials.</p>
+    </div>
+  )
+}

--- a/src/auth/pages/jwt/reset-password/ResetPasswordEnterEmail.tsx
+++ b/src/auth/pages/jwt/reset-password/ResetPasswordEnterEmail.tsx
@@ -1,0 +1,25 @@
+import { FormEvent, useState } from 'react'
+
+export default function ResetPasswordEnterEmail() {
+  const [email, setEmail] = useState('')
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault()
+    // TODO: trigger password reset email
+  }
+
+  return (
+    <div>
+      <h2>Reset Password</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <button type="submit">Send reset link</button>
+      </form>
+    </div>
+  )
+}

--- a/src/auth/providers/JWTProvider.tsx
+++ b/src/auth/providers/JWTProvider.tsx
@@ -1,0 +1,23 @@
+import { createContext, ReactNode, useState } from 'react'
+import type { User } from '../_models'
+
+export interface AuthContextValue {
+  user: User | null
+  token: string | null
+  // TODO: add login, logout and other auth methods
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(undefined)
+
+export function JWTProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [token, setToken] = useState<string | null>(null)
+
+  const value: AuthContextValue = {
+    user,
+    token,
+    // TODO: expose auth actions
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
+}

--- a/src/auth/providers/useAuthContext.ts
+++ b/src/auth/providers/useAuthContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react'
+import { AuthContext } from './JWTProvider'
+
+export default function useAuthContext() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) {
+    throw new Error('useAuthContext must be used within JWTProvider')
+  }
+  return ctx
+}


### PR DESCRIPTION
## Summary
- scaffold JWT auth directories and placeholders
- include basic components for login, signup and password reset
- add provider and hooks
- implement modern tailwind-based login form

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6867566552bc8321959fc74d985031c1